### PR TITLE
[feat] Add client key config support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lg-webos-client"
-version = "0.3.0"
-authors = ["kasper.ziemianek@gmail.com"]
+version = "0.3.1"
+authors = ["kasper.ziemianek@gmail.com", "gavinpease@gmail.com"]
 edition = "2018"
 description = "LG webOS client"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LG webos client
+# LG WebOs Client 0.3.1
 
 [![Build Status](https://travis-ci.com/kziemianek/lg-webos-client.svg?branch=main)](https://travis-ci.com/kziemianek/lg-webos-client)
 
@@ -8,30 +8,30 @@ Inspired by [lgtv.js](https://github.com/msloth/lgtv.js)
 
 ## Supported commands
 
-* create toast
-* open browser
-* turn off
-* set channel
-* set input
-* set mute
-* set volume
-* get channel list
-* get current channel
-* open channel
-* get external input list
-* switch input
-* is muted
-* get volume
-* play media
-* stop media
-* pause media
-* rewind media
-* forward media
-* channel up
-* channel down
-* turn 3d on
-* turn 3d off
-* get services list
+* Create toast
+* Open browser
+* Turn off
+* Set channel
+* Set input
+* Set mute
+* Set volume
+* Get channel list
+* Get current channel
+* Open channel
+* Get external input list
+* Switch input
+* Is muted
+* Get volume
+* Play media
+* Stop media
+* Pause media
+* Rewind media
+* Forward media
+* Channel up
+* Channel down
+* Turn 3d on
+* Turn 3d off
+* Get services list
 
 ## Example
 
@@ -43,19 +43,28 @@ lg-webos-client = "0.2.0"
 tokio = { version = "1.2.0", default-features = false, features = ["full"] }
 ```
 
-And then write code
+And then use the following snippet
 
 ```rust
-use lg_webos_client::client::WebosClient;
+use lg_webos_client::client::*;
 use lg_webos_client::command::Command;
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut client = WebosClient::new("ws://192.168.1.62:3000/").await.unwrap();
+    // Note: We must specify the ws protocol, and if we do not have the key, we must just use a blank str.
+    let config = WebOsClientConfig::new("ws://192.168.1.62:3000/","");
+    
+    let mut client = WebosClient::new(config).await.unwrap();
     let resp = client.send_command(Command::GetChannelList).await.unwrap();
     println!("Got response {:?}", resp.payload);
 }
 ```
 
-The code above simply connects to tv in local network and after successfull registration lists all channels.
+The code above simply connects to tv in local network and after a successful registration lists all channels.
+Note that we must specify the `ws` protocol.  If we have a key, we can pass that in the config, and the 
+client will use said key.  If no key is specified, the client will output a key generated from the device.
+
+# Contributors
+* kziemianek
+* GT3CH1

--- a/examples/get-channel-list/main.rs
+++ b/examples/get-channel-list/main.rs
@@ -1,10 +1,12 @@
-use lg_webos_client::client::WebosClient;
+use lg_webos_client::client::*;
 use lg_webos_client::command::Command;
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let mut client = WebosClient::new("ws://192.168.1.62:3000/").await.unwrap();
+    // Note: We must specify the ws protocol, and if we do not have the key, we must just use a blank str.
+    let config = WebOsClientConfig::new("ws://192.168.1.62:3000/", "");
+    let mut client = WebosClient::new(config).await.unwrap();
     let resp = client.send_command(Command::GetChannelList).await.unwrap();
     println!("Got response {:?}", resp.payload);
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -14,8 +14,9 @@ use tokio_tungstenite::tungstenite::Error;
 use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 
 use crate::command::CommandRequest;
-
 use super::command::{create_command, Command, CommandResponse};
+
+use serde::{Serialize, Deserialize};
 
 /// Client for interacting with TV
 pub struct WebosClient {
@@ -24,10 +25,17 @@ pub struct WebosClient {
     ongoing_requests: Arc<Mutex<HashMap<u8, Pinky<CommandResponse>>>>,
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct WebOsClientConfig {
     address: String,
     has_key: bool,
     key: String,
+}
+
+impl ::std::default::Default for WebOsClientConfig {
+    fn default() -> WebOsClientConfig {
+        WebOsClientConfig::new("ws://lgwebostv:3000/", "")
+    }
 }
 
 impl WebOsClientConfig {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -17,105 +17,48 @@ use crate::command::CommandRequest;
 
 use super::command::{create_command, Command, CommandResponse};
 
-static HANDSHAKE: &str = r#"
-{
-    "type": "register",
-    "id": "register_0",
-    "payload": {
-        "forcePairing": false,
-        "pairingType": "PROMPT",
-        "client-key": "694552d52cbf3baca53ba60e7d71a067",
-        "manifest": {
-            "manifestVersion": 1,
-            "appVersion": "1.1",
-            "signed": {
-                "created": "20140509",
-                "appId": "com.lge.test",
-                "vendorId": "com.lge",
-                "localizedAppNames": {
-                    "": "LG Remote App",
-                    "ko-KR": "리모컨 앱",
-                    "zxx-XX": "ЛГ Rэмotэ AПП"
-                },
-                "localizedVendorNames": {
-                    "": "LG Electronics"
-                },
-                "permissions": [
-                    "TEST_SECURE",
-                    "CONTROL_INPUT_TEXT",
-                    "CONTROL_MOUSE_AND_KEYBOARD",
-                    "READ_INSTALLED_APPS",
-                    "READ_LGE_SDX",
-                    "READ_NOTIFICATIONS",
-                    "SEARCH",
-                    "WRITE_SETTINGS",
-                    "WRITE_NOTIFICATION_ALERT",
-                    "CONTROL_POWER",
-                    "READ_CURRENT_CHANNEL",
-                    "READ_RUNNING_APPS",
-                    "READ_UPDATE_INFO",
-                    "UPDATE_FROM_REMOTE_APP",
-                    "READ_LGE_TV_INPUT_EVENTS",
-                    "READ_TV_CURRENT_TIME"
-                ],
-                "serial": "2f930e2d2cfe083771f68e4fe7bb07"
-            },
-            "permissions": [
-                "LAUNCH",
-                "LAUNCH_WEBAPP",
-                "APP_TO_APP",
-                "CLOSE",
-                "TEST_OPEN",
-                "TEST_PROTECTED",
-                "CONTROL_AUDIO",
-                "CONTROL_DISPLAY",
-                "CONTROL_INPUT_JOYSTICK",
-                "CONTROL_INPUT_MEDIA_RECORDING",
-                "CONTROL_INPUT_MEDIA_PLAYBACK",
-                "CONTROL_INPUT_TV",
-                "CONTROL_POWER",
-                "READ_APP_STATUS",
-                "READ_CURRENT_CHANNEL",
-                "READ_INPUT_DEVICE_LIST",
-                "READ_NETWORK_STATE",
-                "READ_RUNNING_APPS",
-                "READ_TV_CHANNEL_LIST",
-                "WRITE_NOTIFICATION_TOAST",
-                "READ_POWER_STATE",
-                "READ_COUNTRY_INFO"
-            ],
-            "signatures": [
-                {
-                    "signatureVersion": 1,
-                    "signature": "eyJhbGdvcml0aG0iOiJSU0EtU0hBMjU2Iiwia2V5SWQiOiJ0ZXN0LXNpZ25pbmctY2VydCIsInNpZ25hdHVyZVZlcnNpb24iOjF9.hrVRgjCwXVvE2OOSpDZ58hR+59aFNwYDyjQgKk3auukd7pcegmE2CzPCa0bJ0ZsRAcKkCTJrWo5iDzNhMBWRyaMOv5zWSrthlf7G128qvIlpMT0YNY+n/FaOHE73uLrS/g7swl3/qH/BGFG2Hu4RlL48eb3lLKqTt2xKHdCs6Cd4RMfJPYnzgvI4BNrFUKsjkcu+WD4OO2A27Pq1n50cMchmcaXadJhGrOqH5YmHdOCj5NSHzJYrsW0HPlpuAx/ECMeIZYDh6RMqaFM2DXzdKX9NmmyqzJ3o/0lkk/N97gfVRLW5hA29yeAwaCViZNCP8iC9aO0q9fQojoa7NQnAtw=="
-                }
-            ]
-        }
-    }
-}
-"#;
 /// Client for interacting with TV
 pub struct WebosClient {
-    write: Box<dyn Sink<Message, Error = Error> + Unpin>,
+    write: Box<dyn Sink<Message, Error=Error> + Unpin>,
     next_command_id: Arc<Mutex<u8>>,
     ongoing_requests: Arc<Mutex<HashMap<u8, Pinky<CommandResponse>>>>,
 }
 
+pub struct WebOsClientConfig {
+    address: String,
+    has_key: bool,
+    key: String,
+}
+
+impl WebOsClientConfig {
+    /// Creates a new client configuration
+    pub fn new(addr: &str, the_key: &str) -> WebOsClientConfig {
+        let address = String::from(addr);
+        let key = String::from(the_key);
+        let has_key = the_key != "";
+        WebOsClientConfig {
+            address,
+            has_key,
+            key,
+        }
+    }
+}
+
 impl WebosClient {
     /// Creates client connected to device with given address
-    pub async fn new(address: &str) -> Result<WebosClient, String> {
-        let url = url::Url::parse(address).expect("Could not parse given address");
+    pub async fn new(config: WebOsClientConfig) -> Result<WebosClient, String> {
+        let url = url::Url::parse(&config.address).expect("Could not parse given address");
         let (ws_stream, _) = connect_async(url).await.expect("Failed to connect");
         debug!("WebSocket handshake has been successfully completed");
         let (write, read) = ws_stream.split();
-        WebosClient::from_stream_and_sink(read, write).await
+        WebosClient::from_stream_and_sink(read, write, config).await
     }
 
     /// Creates client using provided stream and sink
-    pub async fn from_stream_and_sink<T, S>(stream: T, mut sink: S) -> Result<WebosClient, String>
-    where
-        T: Stream<Item = Result<Message, Error>> + 'static + Send,
-        S: Sink<Message, Error = Error> + Unpin + 'static,
+    pub async fn from_stream_and_sink<T, S>(stream: T, mut sink: S, config: WebOsClientConfig) -> Result<WebosClient, String>
+        where
+            T: Stream<Item=Result<Message, Error>> + 'static + Send,
+            S: Sink<Message, Error=Error> + Unpin + 'static,
     {
         let next_command_id = Arc::from(Mutex::from(0));
         let ongoing_requests = Arc::from(Mutex::from(HashMap::new()));
@@ -124,7 +67,14 @@ impl WebosClient {
         tokio::spawn(async move {
             process_messages_from_server(stream, requests_to_process, registration_pinky).await
         });
-        sink.send(Message::text(HANDSHAKE)).await.unwrap();
+
+        let mut handshake = get_handshake();
+        // Check to see if the config has a key, if it does, add it to the handshake.
+        if config.has_key {
+            handshake["payload"]["client-key"] = Value::from(config.key);
+        }
+        let formatted_handshake = format!("{}", handshake);
+        sink.send(Message::text(formatted_handshake)).await.unwrap();
         registration_promise.await;
         Ok(WebosClient {
             write: Box::new(sink),
@@ -186,23 +136,33 @@ async fn process_messages_from_server<T>(
     pending_requests: Arc<Mutex<HashMap<u8, Pinky<CommandResponse>>>>,
     registration_pinky: Pinky<bool>,
 ) where
-    T: Stream<Item = Result<Message, Error>>,
+    T: Stream<Item=Result<Message, Error>>,
 {
     stream
         .for_each(|message| match message {
             Ok(_message) => {
                 if let Some(text_message) = _message.clone().into_text().ok() {
                     if let Ok(json) = serde_json::from_str::<Value>(&text_message) {
+                        println!("JSON Response -> {}", json);
                         if json["type"] == "registered" {
                             registration_pinky.swear(true);
                         } else {
-                            let response = CommandResponse {
-                                id: json["id"].as_i64().unwrap() as u8,
-
-                                payload: Some(json["payload"].clone()),
+                            let mut error: bool = false;
+                            let res = match json["id"].as_i64() {
+                                Some(r) => r,
+                                None => {
+                                    error = true;
+                                    0
+                                }
                             };
-                            let requests = pending_requests.lock().unwrap();
-                            requests.get(&response.id).unwrap().swear(response);
+                            if !error {
+                                let response = CommandResponse {
+                                    id: res as u8,
+                                    payload: Some(json["payload"].clone()),
+                                };
+                                let requests = pending_requests.lock().unwrap();
+                                requests.get(&response.id).unwrap().swear(response);
+                            }
                         }
                     }
                 }
@@ -217,4 +177,87 @@ impl From<&CommandRequest> for Message {
     fn from(request: &CommandRequest) -> Self {
         Message::text(serde_json::to_string(request).unwrap())
     }
+}
+
+/// Get the initial handhsake packet for connecting to a device.
+/// A client-key can be set by something similar to
+/// `get_handshake()["payload"]["client-key"] = ...`
+/// # Return
+///     The initial handshake packet needed to connect to a WebOS device.
+fn get_handshake() -> serde_json::Value {
+    serde_json::json!(
+        {
+        "type": "register",
+        "id": "0",
+        "payload": {
+            "forcePairing": false,
+            "pairingType": "PROMPT",
+            "manifest": {
+                "manifestVersion": 1,
+                "appVersion": "1.1",
+                "signed": {
+                    "created": "20140509",
+                    "appId": "com.lge.test",
+                    "vendorId": "com.lge",
+                    "localizedAppNames": {
+                        "": "LG Remote App",
+                        "ko-KR": "리모컨 앱",
+                        "zxx-XX": "ЛГ Rэмotэ AПП"
+                    },
+                    "localizedVendorNames": {
+                        "": "LG Electronics"
+                    },
+                    "permissions": [
+                        "TEST_SECURE",
+                        "CONTROL_INPUT_TEXT",
+                        "CONTROL_MOUSE_AND_KEYBOARD",
+                        "READ_INSTALLED_APPS",
+                        "READ_LGE_SDX",
+                        "READ_NOTIFICATIONS",
+                        "SEARCH",
+                        "WRITE_SETTINGS",
+                        "WRITE_NOTIFICATION_ALERT",
+                        "CONTROL_POWER",
+                        "READ_CURRENT_CHANNEL",
+                        "READ_RUNNING_APPS",
+                        "READ_UPDATE_INFO",
+                        "UPDATE_FROM_REMOTE_APP",
+                        "READ_LGE_TV_INPUT_EVENTS",
+                        "READ_TV_CURRENT_TIME"
+                    ],
+                    "serial": "2f930e2d2cfe083771f68e4fe7bb07"
+                },
+                "permissions": [
+                    "LAUNCH",
+                    "LAUNCH_WEBAPP",
+                    "APP_TO_APP",
+                    "CLOSE",
+                    "TEST_OPEN",
+                    "TEST_PROTECTED",
+                    "CONTROL_AUDIO",
+                    "CONTROL_DISPLAY",
+                    "CONTROL_INPUT_JOYSTICK",
+                    "CONTROL_INPUT_MEDIA_RECORDING",
+                    "CONTROL_INPUT_MEDIA_PLAYBACK",
+                    "CONTROL_INPUT_TV",
+                    "CONTROL_POWER",
+                    "READ_APP_STATUS",
+                    "READ_CURRENT_CHANNEL",
+                    "READ_INPUT_DEVICE_LIST",
+                    "READ_NETWORK_STATE",
+                    "READ_RUNNING_APPS",
+                    "READ_TV_CHANNEL_LIST",
+                    "WRITE_NOTIFICATION_TOAST",
+                    "READ_POWER_STATE",
+                    "READ_COUNTRY_INFO"
+                ],
+                "signatures": [
+                    {
+                        "signatureVersion": 1,
+                        "signature": "eyJhbGdvcml0aG0iOiJSU0EtU0hBMjU2Iiwia2V5SWQiOiJ0ZXN0LXNpZ25pbmctY2VydCIsInNpZ25hdHVyZVZlcnNpb24iOjF9.hrVRgjCwXVvE2OOSpDZ58hR+59aFNwYDyjQgKk3auukd7pcegmE2CzPCa0bJ0ZsRAcKkCTJrWo5iDzNhMBWRyaMOv5zWSrthlf7G128qvIlpMT0YNY+n/FaOHE73uLrS/g7swl3/qH/BGFG2Hu4RlL48eb3lLKqTt2xKHdCs6Cd4RMfJPYnzgvI4BNrFUKsjkcu+WD4OO2A27Pq1n50cMchmcaXadJhGrOqH5YmHdOCj5NSHzJYrsW0HPlpuAx/ECMeIZYDh6RMqaFM2DXzdKX9NmmyqzJ3o/0lkk/N97gfVRLW5hA29yeAwaCViZNCP8iC9aO0q9fQojoa7NQnAtw=="
+                    }
+                ]
+            }
+        }
+    })
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -28,12 +28,11 @@ pub struct WebosClient {
 #[derive(Serialize, Deserialize)]
 pub struct WebOsClientConfig {
     address: String,
-    has_key: bool,
     key: String,
 }
 
 impl ::std::default::Default for WebOsClientConfig {
-    fn default() -> WebOsClientConfig {
+    fn default() -> Self {
         WebOsClientConfig::new("ws://lgwebostv:3000/", "")
     }
 }
@@ -43,10 +42,8 @@ impl WebOsClientConfig {
     pub fn new(addr: &str, the_key: &str) -> WebOsClientConfig {
         let address = String::from(addr);
         let key = String::from(the_key);
-        let has_key = the_key != "";
         WebOsClientConfig {
             address,
-            has_key,
             key,
         }
     }
@@ -78,7 +75,7 @@ impl WebosClient {
 
         let mut handshake = get_handshake();
         // Check to see if the config has a key, if it does, add it to the handshake.
-        if config.has_key {
+        if config.key == "" {
             handshake["payload"]["client-key"] = Value::from(config.key);
         }
         let formatted_handshake = format!("{}", handshake);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,16 @@
 //!
 //! Create client and send command
 //! ```rust
-//! use lg_webos_client::client::WebosClient;
+//! use lg_webos_client::client::*;
 //! use lg_webos_client::command::Command;
 //!
 //! #[tokio::main]
 //! async fn main() {
 //!     env_logger::init();
-//!     let mut client = WebosClient::new("ws://192.168.1.62:3000/").await.unwrap();
+//!     // Note: We must specify the ws protocol, and if we do not have the key, we must just use a blank str.
+//!     let config = WebOsClientConfig::new("ws://192.168.1.62:3000/","");
+//!
+//!     let mut client = WebosClient::new(config).await.unwrap();
 //!     let resp = client.send_command(Command::GetChannelList).await.unwrap();
 //!     println!("Got response {:?}", resp.payload);
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     env_logger::init();
-//!     // Note: We must specify the ws protocol, and if we do not have the key, we must just use a blank str.
+//!     // Note: We must specify the ws protocol, and if we do not have the key, we must use a blank str.
 //!     let config = WebOsClientConfig::new("ws://192.168.1.62:3000/","");
 //!
 //!     let mut client = WebosClient::new(config).await.unwrap();


### PR DESCRIPTION
Hi!

I noticed that this library does not currently have support for loading a client-key that has already been connected to a WebOS device, so that we can skip the "Allow access" prompt on the devices.  I have added and tested this feature and have been very happy with the results.  

This is how I am now creating the WebosClient
```rust
 let config = WebOsClientConfig::new("ws://<your-ip-here>:3000/", "<your-key-here>");
 let mut client = WebosClient::new(config).await.unwrap();
```

If a key is not specified, then when we initially connect to the TV, the library will output the key for future use.