### PR TITLE
[fix] Client key config not working + clone

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -27,8 +27,8 @@ pub struct WebosClient {
 
 #[derive(Serialize, Deserialize)]
 pub struct WebOsClientConfig {
-    address: String,
-    key: String,
+    pub address: String,
+    pub key: String,
 }
 
 impl ::std::default::Default for WebOsClientConfig {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -75,7 +75,7 @@ impl WebosClient {
 
         let mut handshake = get_handshake();
         // Check to see if the config has a key, if it does, add it to the handshake.
-        if config.key == "" {
+        if config.key != "" {
             handshake["payload"]["client-key"] = Value::from(config.key);
         }
         let formatted_handshake = format!("{}", handshake);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -49,6 +49,17 @@ impl WebOsClientConfig {
     }
 }
 
+impl Clone for WebOsClientConfig {
+    fn clone(&self) -> Self {
+        let addr = self.address.clone();
+        let key = self.key.clone();
+        WebOsClientConfig {
+            address: addr,
+            key,
+        }
+    }
+}
+
 impl WebosClient {
     /// Creates client connected to device with given address
     pub async fn new(config: WebOsClientConfig) -> Result<WebosClient, String> {


### PR DESCRIPTION
Hi,

I just found out that I did introduce a little bit of a logic flaw in pr #4, which completely negated the entire merge.
This PR *actually* fixes that logic error, as well as implementing `Clone` for `WebOsClientConfig` and making the data in that struct public, so a crate like confy can be used to automatically load the configuration.