### PR TITLE
Add the Launch command, that starts a given app by ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Inspired by [lgtv.js](https://github.com/msloth/lgtv.js)
 * Turn 3d on
 * Turn 3d off
 * Get services list
+* Launch an app
 
 ## Example
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -35,7 +35,9 @@ pub enum Command {
     Turn3DOn,
     Turn3DOff,
     GetServicesList,
+    Launch(String, Value),
 }
+
 pub struct CommandResponse {
     pub id: u8,
     pub payload: Option<Value>,
@@ -187,5 +189,11 @@ pub fn create_command(id: u8, cmd: &Command) -> Option<CommandRequest> {
             uri: String::from("ssap://com.webos.service.update/getCurrentSWInformation"),
             payload: None,
         }),
+        Command::Launch(app_id, params) => Some(CommandRequest {
+            id,
+            r#type: String::from("request"),
+            uri: String::from("ssap://system.launcher/launch"),
+            payload: Some(json!({ "id": app_id, "params": params })),
+        })
     }
 }


### PR DESCRIPTION
Since params are app-specific, the serde_json Value is exposed.

Tested successfully on my TV.