### PR TITLE
Store the key from a successful registration, so it can be reused

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,18 @@ use lg_webos_client::command::Command;
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    // Note: We must specify the ws protocol, and if we do not have the key, we must just use a blank str.
-    let config = WebOsClientConfig::new("ws://192.168.1.62:3000/","");
+    // Note: We must specify the ws protocol, and if we do not have the key, we pass None.
+    let config = WebOsClientConfig::new("ws://192.168.1.62:3000/", None);
     
     let mut client = WebosClient::new(config).await.unwrap();
+    // Registration successful, store the key for later.
+    let key = client.key;
     let resp = client.send_command(Command::GetChannelList).await.unwrap();
     println!("Got response {:?}", resp.payload);
+
+    // We can reuse the key.
+    let config = WebOsClientConfig::new("ws://192.168.1.62:3000/", key);
+    // ...
 }
 ```
 

--- a/examples/get-channel-list/main.rs
+++ b/examples/get-channel-list/main.rs
@@ -4,9 +4,10 @@ use lg_webos_client::command::Command;
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    // Note: We must specify the ws protocol, and if we do not have the key, we must just use a blank str.
-    let config = WebOsClientConfig::new("ws://192.168.1.62:3000/", "");
+    // Note: We must specify the ws protocol, and if we do not have the key, we just specify None.
+    let config = WebOsClientConfig::new("ws://192.168.1.62:3000/", None);
     let mut client = WebosClient::new(config).await.unwrap();
+    println!("The key for next time you build WebOsClientConfig: {:?}", client.key);
     let resp = client.send_command(Command::GetChannelList).await.unwrap();
     println!("Got response {:?}", resp.payload);
 }


### PR DESCRIPTION
This also changes the key parameter to an Option to better capture the fact it's, well, optional.

I think this feature is very important to make good use of this crate. Otherwise we need to bug the user all the time with the prompt.