### PR TITLE
Add support for sending luna commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,15 @@ license-file = "LICENSE"
 keywords = ["lg", "webos", "client"]
 
 [dependencies]
-tokio-tungstenite = "0.18.0"
-futures = "0.3.25"
-futures-util = "0.3.25"
-tokio = { version = "1.24.1", default-features = false, features = ["rt"] }
-url = "2.3.1"
-serde_json = "1.0.91"
-serde = { version = "1.0.152", features = ["derive"]}
-log = "0.4.17"
+tokio-tungstenite = { version = "0.24.0", features = ["url"]}
+futures = "0.3.31"
+futures-util = "0.3.31"
+tokio = { version = "1.40.0", default-features = false, features = ["rt"] }
+url = "2.5.2"
+serde_json = "1.0.128"
+serde = { version = "1.0.210", features = ["derive"]}
+log = "0.4.22"
 
 [dev-dependencies]
-env_logger = "0.10.0"
-tokio = { version = "1.24.1", default-features = false, features = ["full"] }
+env_logger = "0.11.5"
+tokio = { version = "1.40.0", default-features = false, features = ["full"] }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -140,7 +140,7 @@ where
             cmds.into_iter()
                 .map(|cmd| async { self.prepare_command_to_send(cmd).await }),
         )
-            .await;
+        .await;
         let messages: Vec<Result<Message, Error>> = commands
             .into_iter()
             .map(|command| {

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -5,12 +5,14 @@ use serde_json::{json, Value};
 #[serde(rename_all = "camelCase")]
 pub struct CommandRequest {
     id: String,
-    r#type: String,
+    r#type: String, // Required by lg api
     uri: String,
     payload: Option<Value>,
 }
 
 pub enum Command {
+    CreateAlert(Value),
+    CloseAlert(String),
     CreateToast(String),
     OpenBrowser(String),
     TurnOff,
@@ -46,6 +48,18 @@ pub struct CommandResponse {
 
 pub fn create_command(id: String, cmd: Command) -> CommandRequest {
     match cmd {
+        Command::CreateAlert(payload) => CommandRequest {
+            id,
+            r#type: String::from("request"),
+            uri: String::from("ssap://system.notifications/createAlert"),
+            payload: Some(payload),
+        },
+        Command::CloseAlert(alert_id) => CommandRequest {
+            id,
+            r#type: String::from("request"),
+            uri: String::from("ssap://system.notifications/closeAlert"),
+            payload: Some(json!({"alertId": alert_id})),
+        },
         Command::CreateToast(text) => CommandRequest {
             id,
             r#type: String::from("request"),


### PR DESCRIPTION
Luna commands are a lot more powerful and normally not exposed via the websocket api. 

Example of use to change backlight levels:
```rust
const LUNA_SET_CONFIGS: &'static str = "com.webos.service.config/setConfigs";
const LUNA_SET_SYSTEM_SETTINGS: &'static str = "com.webos.settingsservice/setSystemSettings";
const LUNA_TURN_ON_SCREEN_SAVER: &'static str = "com.webos.service.tvpower/power/turnOnScreenSaver";
const LUNA_REBOOT_TV: &'static str = "com.webos.service.tvpower/power/reboot";
const LUNA_REBOOT_TV_WO4: &'static str = "com.webos.service.tv.power/reboot";
const LUNA_SHOW_INPUT_PICKER: &'static str = "com.webos.surfacemanager/showInputPicker";
const LUNA_SET_DEVICE_INFO: &'static str = "com.webos.service.eim/setDeviceInfo";
const LUNA_EJECT_DEVICE: &'static str = "com.webos.service.attachedstoragemanager/ejectDevice";
const LUNA_SET_TPC: &'static str = "com.webos.service.oledepl/setTemporalPeakControl";
const LUNA_SET_GSR: &'static str = "com.webos.service.oledepl/setGlobalStressReduction";
const LUNA_SET_WHITE_BALANCE: &'static str = "com.webos.service.pqcontroller/setWhiteBalance";

let category = "picture";

let params = json!(
 {
   "category": category,
   "settings": {
     "backlight": 50
   }
  }
);

client.send_luna_command(LUNA_SET_SYSTEM_SETTINGS, params).await.unwrap();
```