### PR TITLE
Add command to get current audio output

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -38,7 +38,7 @@ pub enum Command {
     Turn3DOff,
     GetServicesList,
     Launch(String, Value),
-    GetAudioOutputs,
+    GetAudioOutput,
 }
 
 #[derive(Debug)]
@@ -211,7 +211,7 @@ pub fn create_command(id: String, cmd: Command) -> CommandRequest {
             uri: String::from("ssap://system.launcher/launch"),
             payload: Some(json!({ "id": app_id, "params": params })),
         },
-        Command::GetAudioOutputs => CommandRequest {
+        Command::GetAudioOutput => CommandRequest {
             id,
             r#type: String::from("request"),
             uri: String::from("ssap://audio/getSoundOutput"),

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -38,6 +38,7 @@ pub enum Command {
     Turn3DOff,
     GetServicesList,
     Launch(String, Value),
+    GetAudioOutputs,
 }
 
 #[derive(Debug)]
@@ -209,6 +210,12 @@ pub fn create_command(id: String, cmd: Command) -> CommandRequest {
             r#type: String::from("request"),
             uri: String::from("ssap://system.launcher/launch"),
             payload: Some(json!({ "id": app_id, "params": params })),
+        },
+        Command::GetAudioOutputs => CommandRequest {
+            id,
+            r#type: String::from("request"),
+            uri: String::from("ssap://audio/getSoundOutput"),
+            payload: None,
         },
     }
 }


### PR DESCRIPTION
Small update that allows to get current audio output:
Example result:
`Autio output list: Some(Object {"returnValue": Bool(true), "soundOutput": String("headphone")})`